### PR TITLE
build fix for debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: speek
 Section: net
 Priority: optional
 Maintainer: Speek <contact@speek.network>
-Build-Depends: debhelper (>= 9), pkg-config, libevent-dev, libssl-dev, libprotobuf-dev, protobuf-compiler, qtbase5-dev, qtdeclarative5-dev, qttools5-dev-tools, tor, make
+Build-Depends: debhelper (>= 9), pkg-config, libevent-dev, libssl-dev, libprotobuf-dev, protobuf-compiler, qtbase5-dev, qtdeclarative5-dev, qttools5-dev-tools, qtquickcontrols2-5-dev, tor, make
 Standards-Version: 4.4.1
 Homepage: https://speek.network/
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,11 +1,16 @@
 #!/usr/bin/make -f
+# -*- makefile -*-
+
 export QT_SELECT=qt5
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
 
 %:
 	dh $@ --buildsystem=qmake --parallel
 
-#override_dh_auto_configure:
-#	dh_auto_configure $(AC_OPTS)
+override_dh_auto_configure:
+	dh_auto_configure -- src/
 
 #override_dh_auto_install:
 #	dh_auto_install


### PR DESCRIPTION
This change was necessary for the debian package build to run, on my machine (with the command `dpkg-buildpackage -rfakeroot -us -uc -nc -I".git*"`. Haven't tested it in a buildd environment).

However, the build still fails for me in the "check" phase. Tests of `tst_cryptokey` are succeessfull, but the built `tst_contactidvalidator` binary segfaults. I didn't look into that.

```
[...]
make -f Makefile.Release check
make[4]: Entering directory '/tmp/speek.git/tests/tst_cryptokey'
cd /tmp/speek.git/src/qmake_includes/../../build/release/tst_cryptokey && /tmp/speek.git/tests/tst_cryptokey/target_wrapper.sh  ./tst_cryptokey 
********* Start testing of TestCryptoKey *********
Config: Using QtTest library 5.15.2, Qt 5.15.2 (x86_64-little_endian-lp64 shared (dynamic) release build; by GCC 10.2.1 20210110), debian 11
PASS   : TestCryptoKey::initTestCase()
PASS   : TestCryptoKey::loadFromServiceId()
PASS   : TestCryptoKey::loadFromKeyBlob()
PASS   : TestCryptoKey::encodedKeyBlob()
PASS   : TestCryptoKey::torServiceId()
PASS   : TestCryptoKey::signData()
PASS   : TestCryptoKey::verifYData()
PASS   : TestCryptoKey::cleanupTestCase()
Totals: 8 passed, 0 failed, 0 skipped, 0 blacklisted, 32ms
********* Finished testing of TestCryptoKey *********
make[4]: Leaving directory '/tmp/speek.git/tests/tst_cryptokey'
make[3]: Leaving directory '/tmp/speek.git/tests/tst_cryptokey'
cd tst_contactidvalidator/ && ( test -e Makefile || /usr/lib/qt5/bin/qmake -o Makefile /tmp/speek.git/src/tests/tst_contactidvalidator/tst_contactidvalidator.pro 'QMAKE_CFLAGS_RELEASE=-g -O2 -ffile-prefix-map=/tmp/speek.git=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2' 'QMAKE_CFLAGS_DEBUG=-g -O2 -ffile-prefix-map=/tmp/speek.git=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2' 'QMAKE_CXXFLAGS_RELEASE=-g -O2 -ffile-prefix-map=/tmp/speek.git=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2' 'QMAKE_CXXFLAGS_DEBUG=-g -O2 -ffile-prefix-map=/tmp/speek.git=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2' 'QMAKE_LFLAGS_RELEASE=-Wl,-z,relro -Wl,-z,now' 'QMAKE_LFLAGS_DEBUG=-Wl,-z,relro -Wl,-z,now' QMAKE_STRIP=: PREFIX=/usr ) && make -f Makefile check
make[3]: Entering directory '/tmp/speek.git/tests/tst_contactidvalidator'
make -f Makefile.Release check
make[4]: Entering directory '/tmp/speek.git/tests/tst_contactidvalidator'
cd /tmp/speek.git/src/qmake_includes/../../build/release/tst_contactidvalidator && /tmp/speek.git/tests/tst_contactidvalidator/target_wrapper.sh  ./tst_contactidvalidator 
Segmentation fault
make[4]: *** [Makefile.Release:207: check] Error 139
make[4]: Leaving directory '/tmp/speek.git/tests/tst_contactidvalidator'
make[3]: *** [Makefile:298: release-check] Error 2
make[3]: Leaving directory '/tmp/speek.git/tests/tst_contactidvalidator'
make[2]: *** [Makefile:341: sub-tst_contactidvalidator-check_ordered] Error 2
make[2]: Leaving directory '/tmp/speek.git/tests'
make[1]: *** [Makefile:499: sub-tests-check_ordered] Error 2
make[1]: Leaving directory '/tmp/speek.git'
dh_auto_test: error: make -j8 check returned exit code 2
make: *** [debian/rules:10: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```