### PR TITLE
[Feature Branch] Implement Concurrent Chunk Transfers to Enhance File Transfer Speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,5 @@ ricochet-refresh
 \.vscode/c_cpp_properties\.json
 \.vscode/
 notes/*
+build-tego-Desktop-Debug
 build-tego-Desktop-Release

--- a/src/libtego/source/protocol/FileChannel.cpp
+++ b/src/libtego/source/protocol/FileChannel.cpp
@@ -420,6 +420,10 @@ void FileChannel::handleFileHeaderResponse(const Data::File::FileHeaderResponse 
 
     const auto id = message.file_id();
 
+    auto version = 0;
+    if(message.has_version())
+        version = message.version();
+
     auto it = outgoingTransfers.find(id);
     if (it == outgoingTransfers.end())
     {
@@ -434,7 +438,8 @@ void FileChannel::handleFileHeaderResponse(const Data::File::FileHeaderResponse 
 
     if (response == tego_file_transfer_response_accept)
     {
-        sendNextChunk(id);
+        for(size_t i = 0;i<(version >= 17 ? MaxConcurrentChunks : 1);i++)
+            sendNextChunk(id);
         it->second.beginTime = std::chrono::system_clock::now();
     }
     else
@@ -476,7 +481,11 @@ void FileChannel::handleFileChunk(const Data::File::FileChunk &message)
     {
         auto& itr = it->second;
         const auto& chunk_data = message.chunk_data();
+        mMutexReceive.lock();
+        if(message.has_chunk_pos())
+            itr.stream.seekp(message.chunk_pos());
         itr.stream.write(chunk_data.data(), chunk_data.size());
+        mMutexReceive.unlock();
 
         // emit progress callback
         const auto id = message.file_id();
@@ -580,15 +589,6 @@ void FileChannel::handleFileChunkAck(const Data::File::FileChunkAck &message)
     }
 
     const auto& otr = it->second;
-
-    // verify the ack corresponds to how many bytes we've sent
-    if (message.bytes_received() != otr.offset)
-    {
-        // acks currently always come between sending chunks, so our bytes sent and their bytes received should
-        // not diverge
-        emitFatalError("mismatch between bytes we have sent and the bytes the receiver claims to have received", tego_file_transfer_result_failure, true);
-        return;
-    }
 
     emit this->fileTransferProgress(otr.id, tego_file_transfer_direction_receiving, otr.offset, otr.size);
 
@@ -727,6 +727,7 @@ void FileChannel::acceptFile(tego_file_transfer_id_t id, const std::string& dest
     auto response = std::make_unique<Data::File::FileHeaderResponse>();
     response->set_response(tego_file_transfer_response_accept);
     response->set_file_id(id);
+    response->set_version(17);
 
     Data::File::Packet packet;
     packet.set_allocated_file_header_response(response.release());
@@ -801,6 +802,8 @@ bool FileChannel::cancelTransfer(tego_file_transfer_id_t id)
 
 void FileChannel::sendNextChunk(tego_file_transfer_id_t id)
 {
+    QMutexLocker ml(&mMutexSend);
+
     Q_ASSERT(direction() == Outbound);
 
     if (auto it = outgoingTransfers.find(id); it != outgoingTransfers.end())
@@ -834,12 +837,14 @@ void FileChannel::sendNextChunk(tego_file_transfer_id_t id)
         }
         Q_ASSERT(static_cast<tego_file_size_t>(chunkSize) <= FileMaxChunkSize);
 
+        const auto chunkOffset = otr.offset;
         otr.offset += chunkSize;
 
         // build our chunk
         auto chunk = std::make_unique<Data::File::FileChunk>();
         chunk->set_file_id(id);
         chunk->set_chunk_data(std::begin(chunkBuffer), chunkSize);
+        chunk->set_chunk_pos(chunkOffset);
 
         Data::File::Packet packet;
         packet.set_allocated_file_chunk(chunk.release());

--- a/src/libtego/source/protocol/FileChannel.cpp
+++ b/src/libtego/source/protocol/FileChannel.cpp
@@ -590,7 +590,11 @@ void FileChannel::handleFileChunkAck(const Data::File::FileChunkAck &message)
 
     const auto& otr = it->second;
 
-    emit this->fileTransferProgress(otr.id, tego_file_transfer_direction_receiving, otr.offset, otr.size);
+    if(message.bytes_received() > otr.size){
+        emitFatalError("mismatch between the total bytes of the file sent and the bytes the receiver claims to have received", tego_file_transfer_result_failure, true);
+        return;
+    }
+    emit this->fileTransferProgress(otr.id, tego_file_transfer_direction_receiving, message.bytes_received(), otr.size);
 
     // send the next chunk until we are done
     if(otr.offset < otr.size)

--- a/src/libtego/source/protocol/FileChannel.h
+++ b/src/libtego/source/protocol/FileChannel.h
@@ -123,7 +123,7 @@ private:
     };
     // 63 kb, max packet size is UINT16_MAX (ak 65535, 64k - 1) so leave space for other data
     constexpr static tego_file_size_t FileMaxChunkSize = 63*1024; // bytes
-    const size_t MaxConcurrentChunks = 15;
+    const size_t MaxConcurrentChunks = 50;
     // intermediate buffer we load chunks from disk into
     // each access to this buffer happens on the same thread, and only within the scope of a function
     // so no need to worry about synchronization or sharing between file transfers

--- a/src/libtego/source/protocol/FileChannel.h
+++ b/src/libtego/source/protocol/FileChannel.h
@@ -123,10 +123,14 @@ private:
     };
     // 63 kb, max packet size is UINT16_MAX (ak 65535, 64k - 1) so leave space for other data
     constexpr static tego_file_size_t FileMaxChunkSize = 63*1024; // bytes
+    const size_t MaxConcurrentChunks = 15;
     // intermediate buffer we load chunks from disk into
     // each access to this buffer happens on the same thread, and only within the scope of a function
     // so no need to worry about synchronization or sharing between file transfers
     char chunkBuffer[FileMaxChunkSize];
+
+    QMutex mMutexReceive;
+    QMutex mMutexSend;
 
     // file transfers we are sending
     std::map<tego_file_transfer_id_t, outgoing_transfer_record> outgoingTransfers;

--- a/src/libtego/source/protocol/FileChannel.proto
+++ b/src/libtego/source/protocol/FileChannel.proto
@@ -59,11 +59,13 @@ message FileHeaderAck {
 message FileHeaderResponse {
     optional uint32 file_id = 1;
     optional int32 response = 2;
+    optional uint32 version = 3;
 }
 
 message FileChunk {
     optional uint32 file_id = 1;
     optional bytes chunk_data = 2;
+    optional uint32 chunk_pos = 3;
 }
 message FileChunkAck {
     optional uint32 file_id = 1;

--- a/src/libtego_ui/shims/ConversationModel.cpp
+++ b/src/libtego_ui/shims/ConversationModel.cpp
@@ -701,7 +701,8 @@ QMutex ConversationModel::mutex;
         if (row >= 0)
         {
             MessageData &data = messages[row];
-            data.bytesTransferred = bytesTransferred;
+            if(bytesTransferred > data.bytesTransferred)
+                data.bytesTransferred = bytesTransferred;
             data.transferStatus = InProgress;
 
             if(data.bytesTransferredFewSecAgo == 0 || QDateTime::currentMSecsSinceEpoch() - data.timeBytesTransferredFewSecAgo.toMSecsSinceEpoch() > 3000){

--- a/src/libtego_ui/shims/ConversationModel.h
+++ b/src/libtego_ui/shims/ConversationModel.h
@@ -163,6 +163,9 @@ namespace shims
             quint64 bytesTransferred = 0;
             TransferDirection transferDirection = InvalidDirection;;
             TransferStatus transferStatus = InvalidTransfer;
+            quint64 bytesTransferredFewSecAgo = 0;
+            QDateTime timeBytesTransferredFewSecAgo = {};
+            quint64 transferDownloadSpeed = 0;
             #ifdef ANDROID
             QString filePath = {};
             QString fileTransferPath = {};

--- a/src/libtego_ui/ui/qml/MessageDelegate.qml
+++ b/src/libtego_ui/ui/qml/MessageDelegate.qml
@@ -359,7 +359,7 @@ Column {
                             height: styleHelper.pointSize * 1.5
 
                             text: model.transfer ? model.transfer.statusString : ""
-                            font.pointSize: filename.font.pointSize * 0.8;
+                            font.pointSize: filename.font.pointSize * 0.75;
                             color: Qt.lighter(filename.color, 1.5)
                             Accessible.role: Accessible.StaticText
                             Accessible.name: text


### PR DESCRIPTION
This pull request introduces a new feature that enables multiple concurrent chunk transfers. We can considerably minimize the time it takes to transfer large files by transferring the chunks simultaneously. The first commit provides parallel chunk transfers, while the second commit focuses on improving the sender's experience by displaying only the actually received bytes. 